### PR TITLE
Add receipt email to Stripe charge request

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,8 @@ function charge(req, res, next) {
         amount: donationAmount,
         currency: "usd",
         source: stripeToken.id,
-        description: "Installation"
+        description: "Installation",
+        receipt_email: stripeToken.email
       },
       function(err, charge) {
         if (err) {


### PR DESCRIPTION
Affects one time Installation charges only, in the one time donation function.